### PR TITLE
Added the functionality to check for the minimum supported kubernetes version

### DIFF
--- a/operator/controllers/constants.go
+++ b/operator/controllers/constants.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
 
 const (
@@ -104,6 +105,8 @@ const (
 	OtelPprofPort = "otel-pprof"
 	// OtelZpagesPort string.
 	OtelZpagesPort = "otel-zpages"
+	//  MinimumKubernetesVersion defines minimum kubernetes version required by Aperture
+	MinimumKubernetesVersion = "v1.23.0"
 )
 
 var (
@@ -142,4 +145,6 @@ var (
 	CertDir = filepath.Join(".", "certs")
 	// PoliciesDir defines policies directory for tests.
 	PoliciesDir = filepath.Join(".", "policies")
+	// Stores current kubernetes version
+	CurrentKubernetesVersion *apimachineryversion.Info
 )

--- a/operator/main.go
+++ b/operator/main.go
@@ -25,6 +25,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	"k8s.io/client-go/dynamic"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/discovery"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -112,6 +113,20 @@ func main() {
 	dynamicClient, err := dynamic.NewForConfig(ctrl.GetConfigOrDie())
 	if err != nil {
 		setupLog.Error(err, "unable to create Dynamic Client")
+		os.Exit(1)
+	}
+
+	// Creating the discovery client
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		setupLog.Error(err, "unable to create Discovery Client")
+		os.Exit(1)
+	}
+
+	// Querying the local kubernetes version
+	controllers.CurrentKubernetesVersion, err = discoveryClient.ServerVersion()
+	if err != nil {
+		setupLog.Error(err, "unable to get the local kubernetes version")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

### Description of change

Created an event to be generated by the Agent and Controller if in case the minimum Kubernetes version is not satisfied.

To grab the current Kubernetes version followed the same method as kubectl: https://github.com/kubernetes/kubectl/blob/393c40f5c4acbe48edbc70f8c8696bb623744b76/pkg/cmd/version/version.go#L139

aperture-agent-manager log:

```
1.6685863398395433e+09	DEBUG	events	Kubernetes version v1.25.0 is not supported. Please use a kubernetes cluster with version v1.27.0 or above	{"type": "Warning", "object": {"kind":"Agent","namespace":"aperture-agent","name":"agent","uid":"ffe0db7d-fcf5-4685-84b2-da04ae7534f6","apiVersion":"fluxninja.com/v1alpha1","resourceVersion":"14668896"}, "reason": "MinimumKubernetesVersionFail"}
```

aperture-controller-manager log:

```
1.6685863398325784e+09	DEBUG	events	Kubernetes version v1.25.0 is not supported. Please use a kubernetes cluster with version v1.27.0 or above	{"type": "Warning", "object": {"kind":"Controller","namespace":"aperture-controller","name":"controller","uid":"26df4d5c-56af-453e-be98-68a1e1ecf63b","apiVersion":"fluxninja.com/v1alpha1","resourceVersion":"14668895"}, "reason": "MinimumKubernetesVersionFail"}
```

The minimum version was kept `1.27.0` for testing purposes

##### Checklist

- [x] Tested in playground or other setup
- [ ] Documentation is changed or added
- [ ] Tests and/or benchmarks are included
- [ ] Breaking changes

CC: @hdkshingala
